### PR TITLE
avoid generating a useless dependency on tomli when using Py3.11+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,10 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Typing :: Typed",
 ]
-dependencies = [ "domdf-python-tools>=2.8.0", "tomli>=1.2.3",]
+dependencies = [
+ "domdf-python-tools>=2.8.0",
+ "tomli>=1.2.3; python_version < 3.11",
+]
 dynamic = []
 
 [project.license]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,10 +28,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Typing :: Typed",
 ]
-dependencies = [
- "domdf-python-tools>=2.8.0",
- "tomli>=1.2.3; python_version < 3.11",
-]
+dependencies = [ "domdf-python-tools>=2.8.0", 'tomli>=1.2.3; python_version < "3.11"',]
 dynamic = []
 
 [project.license]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 domdf-python-tools>=2.8.0
-tomli>=1.2.3
+tomli>=1.2.3; python_version < "3.11"

--- a/tests/tests_for_tomliw/test_style.py
+++ b/tests/tests_for_tomliw/test_style.py
@@ -1,10 +1,12 @@
+# stdlib
 import sys
+
 if sys.version_info >= (3, 11):
-    # stdlib
-    import tomllib as tomli
+	# stdlib
+	import tomllib as tomli
 else:
-    # 3rd party
-    import tomli
+	# 3rd party
+	import tomli
 
 # this package
 import dom_toml

--- a/tests/tests_for_tomliw/test_style.py
+++ b/tests/tests_for_tomliw/test_style.py
@@ -1,5 +1,10 @@
-# 3rd party
-import tomli
+import sys
+if sys.version_info >= (3, 11):
+    # stdlib
+    import tomllib as tomli
+else:
+    # 3rd party
+    import tomli
 
 # this package
 import dom_toml

--- a/tests/tests_for_tomliw/test_valid.py
+++ b/tests/tests_for_tomliw/test_valid.py
@@ -1,4 +1,5 @@
 # stdlib
+import sys
 from decimal import Decimal
 from math import isnan
 from pathlib import Path
@@ -6,7 +7,13 @@ from typing import Union
 
 # 3rd party
 import pytest
-import tomli
+
+if sys.version_info >= (3, 11):
+    # stdlib
+    import tomllib as tomli
+else:
+    # 3rd party
+    import tomli
 
 # this package
 import dom_toml

--- a/tests/tests_for_tomliw/test_valid.py
+++ b/tests/tests_for_tomliw/test_valid.py
@@ -9,11 +9,11 @@ from typing import Union
 import pytest
 
 if sys.version_info >= (3, 11):
-    # stdlib
-    import tomllib as tomli
+	# stdlib
+	import tomllib as tomli
 else:
-    # 3rd party
-    import tomli
+	# 3rd party
+	import tomli
 
 # this package
 import dom_toml


### PR DESCRIPTION
Hi,

I'm slowly removing usage of these backports from Debian:

https://wiki.debian.org/Python/Backports